### PR TITLE
add beforeReset hook

### DIFF
--- a/blueprint/core/blueprint_ReactApplicationRoot.h
+++ b/blueprint/core/blueprint_ReactApplicationRoot.h
@@ -371,6 +371,8 @@ namespace blueprint
          **/
         BundleEvalCallback afterBundleEval;
 
+        std::function<void()> beforeReset;
+
         //==============================================================================
         void handleRuntimeError(const EcmascriptEngine::Error& err)
         {
@@ -415,7 +417,8 @@ namespace blueprint
         void handleBundleChanged(const juce::File& bundle)
         {
             JUCE_ASSERT_MESSAGE_THREAD
-
+          if (beforeReset)
+              beforeReset();
             engine.reset();
             initViewManager();
             evaluate(bundle);


### PR DESCRIPTION
react application rootに`beforeReset` hookの追加
ViewManagerのinitとEcmascriptEngineをresetする前に発火するコールバック