### PR TITLE
Add border to boundary of Blueprint::View for debugging purpose

### DIFF
--- a/blueprint/core/blueprint_View.cpp
+++ b/blueprint/core/blueprint_View.cpp
@@ -222,9 +222,13 @@ namespace blueprint
                 g.fillAll(c);
         }
 #ifndef BLUEPRINT_SHOW_DEBUGBORDER
-    #define BLUEPRINT_SHOW_DEBUGBORDER 1
+    #ifdef JUCE_DEBUG
+        #define BLUEPRINT_SHOW_DEBUGBORDER 1
+    #else
+        #define BLUEPRINT_SHOW_DEBUGBORDER 0
+    #endif
 #endif
-        if constexpr(JUCE_DEBUG && BLUEPRINT_SHOW_DEBUGBORDER)
+        if constexpr(BLUEPRINT_SHOW_DEBUGBORDER)
         {
             juce::Path border;
             float borderWidth =1.0;

--- a/blueprint/core/blueprint_View.cpp
+++ b/blueprint/core/blueprint_View.cpp
@@ -221,6 +221,24 @@ namespace blueprint
             if (!c.isTransparent())
                 g.fillAll(c);
         }
+#ifndef BLUEPRINT_SHOW_DEBUGBORDER
+    #define BLUEPRINT_SHOW_DEBUGBORDER 1
+#endif
+        if constexpr(JUCE_DEBUG && BLUEPRINT_SHOW_DEBUGBORDER)
+        {
+            juce::Path border;
+            float borderWidth =1.0;
+            auto c = juce::Colours::green;
+                    auto borderBounds = getLocalBounds().toFloat().reduced(borderWidth * 0.5f);
+            auto width = borderBounds.getWidth();
+            auto height = borderBounds.getHeight();
+            auto minLength = std::min(width, height);
+
+            border.addRoundedRectangle(borderBounds, 0);
+            g.setColour(c);
+            g.strokePath(border, juce::PathStrokeType(borderWidth));
+            g.reduceClipRegion(border);
+        }
     }
 
     //==============================================================================


### PR DESCRIPTION
Debugコンフィグの時にBlueprint::ViewのBounding box上に緑色の枠線を表示する。
デバッグ中だけど消したい時は
`#define BLUEPRINT_SHOW_DEBUGBORDER 0`をどこかで定義する。