### PR TITLE
don't consume keypress events.

### DIFF
--- a/blueprint/core/blueprint_ReactApplicationRoot.h
+++ b/blueprint/core/blueprint_ReactApplicationRoot.h
@@ -175,7 +175,10 @@ namespace blueprint
                engine.debuggerAttach();
            }
 #endif
-            return true;
+
+            // blueprint 側でキー入力を消費してしまわないようにするために、
+            // かならず false を返すようにしている。(yuasa)
+            return false;
         }
 
         //==============================================================================

--- a/blueprint/core/blueprint_View.cpp
+++ b/blueprint/core/blueprint_View.cpp
@@ -310,7 +310,9 @@ namespace blueprint
         if (auto* parent = findParentComponentOfClass<ReactApplicationRoot>())
             parent->keyPressed(key);
 
-        return true;
+        // blueprint 側でキー入力を消費してしまわないようにするために、
+        // かならず false を返すようにしている。(yuasa)
+        return false;
     }
 
     void View::dispatchViewEvent (const juce::String& eventType, const juce::var& e)


### PR DESCRIPTION
今の blueprint の仕組みでは、 keyPressed() コールバックで必ずキー入力が消費されたことになっていて、プラグイン上で本来消費していないはずのキー入力もホストに対して送られなくなってしまう問題がある。

これに対して、 keyPressed() コールバックで必ず false を返すようにし、 blueprint 側でキー入力が消費されないようにした。